### PR TITLE
Added local maven repository caching to main build and OWASP build. T…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,22 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Set up JDK 21
         uses: oracle-actions/setup-java@v1
         with:
           website: jdk.java.net
           release: 21
-      - run: ./mvnw clean install -Pall-quality-gates -B
+
+      - name: Run Maven
+        run: ./mvnw clean install -Pall-quality-gates -B
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/latest-versions.yml
+++ b/.github/workflows/latest-versions.yml
@@ -14,4 +14,6 @@ jobs:
         with:
           website: jdk.java.net
           release: 21
-      - run: ./mvnw clean versions:update-properties scm:check-local-modification -U -B
+
+      - name: Run Maven
+        run: ./mvnw clean versions:update-properties scm:check-local-modification -U -B

--- a/.github/workflows/owasp.yml
+++ b/.github/workflows/owasp.yml
@@ -9,9 +9,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "datetime=$(/bin/date -u "+%Y%m%d%H")" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Restore cached Maven dependencies
+        uses: actions/cache/restore@v3
+        with:
+          path: ~/.m2/repository
+          # Using datetime in cache key as OWASP database may change, without the pom changing
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}
+            ${{ runner.os }}-maven-
+
       - name: Set up JDK 21
         uses: oracle-actions/setup-java@v1
         with:
           website: jdk.java.net
           release: 21
-      - run: ./mvnw clean install dependency-check:check -DnvdApiKey= -B
+
+      - name: Run Maven
+        run: ./mvnw clean install dependency-check:check -DnvdApiKey=${{ secrets.NVD_API_KEY }} -DnvdApiDelay=6000 -B
+        
+      # Want the Maven dependencies to be cached even if the build fails as we want the OWASP database cached, regardless of whether vulnerabilities are found or not
+      - name: Cache Maven dependencies
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -308,9 +308,6 @@
                     <artifactId>dependency-check-maven</artifactId>
                     <version>${dependency-check-maven.version}</version>
                     <configuration>
-                        <!-- NVD API Key obtained from  https://nvd.nist.gov/developers/request-an-api-key -->
-                        <nvdApiKey>${nvdApiKey}</nvdApiKey>
-
                         <!-- Assembly analyzer disabled because we don't have any .NET code/dlls -->
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <!-- Node and retirejs analyzer disabled, because any js floating around isn't part of the main app -->


### PR DESCRIPTION
…his improves the build time of the main build and also prevents the OWASP database from having to be recreated each time the OWASP build runs. Also updated the nvd delay to the recommended 6 seconds.